### PR TITLE
Bump compileSdkVersion: 30 -> 34

### DIFF
--- a/shake_gesture_android/android/build.gradle
+++ b/shake_gesture_android/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     namespace 'dev.fluttercommunity.shake_gesture_android'
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Bumps the compileSdkVersion from 30 to 34.

This is important, because without this, building an apk (in our case) leads to linker errors like:
- AAPT: error: resource android:attr/lStar
- Android resource linking failed

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
