### PR TITLE
fix(ios): support UISceneDelegate window detection for shake events

### DIFF
--- a/shake_gesture_ios/ios/Classes/ShakeGesturePlugin.swift
+++ b/shake_gesture_ios/ios/Classes/ShakeGesturePlugin.swift
@@ -19,13 +19,18 @@ public class ShakeGesturePlugin: NSObject, FlutterPlugin {
     }
 
     @objc func handleEvent(_ notification: Notification) {
-        if let eventData = notification.userInfo?["window"] as? UIWindow {
-            if let appDelegate = UIApplication.shared.delegate, let window = appDelegate.window {
-                if (window == eventData) {
-                    DispatchQueue.main.async {
-                        self.channel.invokeMethod("onShake", arguments: nil)
-                    }
-                }
+        guard let eventWindow = notification.userInfo?["window"] as? UIWindow else { return }
+        let appWindows: [UIWindow]
+        if #available(iOS 13.0, *) {
+            appWindows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            appWindows = UIApplication.shared.windows
+        }
+        if appWindows.contains(where: { $0 === eventWindow }) {
+            DispatchQueue.main.async {
+                self.channel.invokeMethod("onShake", arguments: nil)
             }
         }
     }


### PR DESCRIPTION
## Problem

With the UIScene lifecycle introduced in Flutter 3.41, `UIApplicationDelegate.window` is `nil` because window management is now handled by `UIWindowScene`. The shake event handler was checking `appDelegate.window` to match the event window, causing shake detection to **silently fail** on any app that has migrated to the UIScene lifecycle.

```swift
// Before — broken with UISceneDelegate (appDelegate.window is nil)
if let appDelegate = UIApplication.shared.delegate, let window = appDelegate.window {
    if (window == eventData) { ... }
}
```

## Fix

Use `UIApplication.shared.connectedScenes` to retrieve windows on iOS 13+ (where `UISceneDelegate` is available), with a fallback to `UIApplication.shared.windows` for iOS 12 and below.

```swift
// After — works with both UISceneDelegate and legacy UIApplicationDelegate
let appWindows: [UIWindow]
if #available(iOS 13.0, *) {
    appWindows = UIApplication.shared.connectedScenes
        .compactMap { $0 as? UIWindowScene }
        .flatMap { $0.windows }
} else {
    appWindows = UIApplication.shared.windows
}
if appWindows.contains(where: { $0 === eventWindow }) { ... }
```

## Tests

All existing unit tests pass:
```
00:00 +2: All tests passed!
```

The native fix was validated manually on a Flutter 3.41 app using the UIScene lifecycle (`UIApplicationSceneManifest` in Info.plist + `FlutterImplicitEngineDelegate`).