### PR TITLE
fix(android): support AGP 9's built-in Kotlin

### DIFF
--- a/shake_gesture_android/android/build.gradle
+++ b/shake_gesture_android/android/build.gradle
@@ -22,7 +22,12 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     compileSdkVersion 34
@@ -34,8 +39,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        }
     }
 
     sourceSets {

--- a/shake_gesture_android/android/build.gradle
+++ b/shake_gesture_android/android/build.gradle
@@ -24,8 +24,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+// android.builtInKotlin lets a project opt out of AGP 9's built-in Kotlin and fall back to the
+// standalone plugin, so it must be honored in addition to the AGP version.
+def builtInKotlin = agpMajor >= 9 && project.findProperty('android.builtInKotlin') != 'false'
 
-if (agpMajor < 9) {
+if (!builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 
@@ -39,9 +42,17 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    if (builtInKotlin) {
+        // JvmTarget.JVM_1_8 needs KGP 1.9.0+; only safe here because AGP 9's built-in Kotlin
+        // doesn't use this module's own (much older) pinned kotlin_version.
+        kotlin {
+            compilerOptions {
+                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+            }
+        }
+    } else {
+        kotlinOptions {
+            jvmTarget = '1.8'
         }
     }
 


### PR DESCRIPTION
Same fix as https://github.com/tpucci/firebase_app_distribution/pull/6 — AGP 9 rejects the standalone `org.jetbrains.kotlin.android` plugin outright:

```
Failed to apply plugin 'org.jetbrains.kotlin.android'
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

Guards the plugin application behind an AGP-major-version check. Tested against a Flutter 3.47 / AGP 9.3.0 app — builds cleanly with this change, fails without it.